### PR TITLE
Instructions for Python 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ sudo apt-get install python-pip
 sudo pip install fusepy
 ```
 
+On Python 2.7 use this instead:
+```
+sudo python -m pip install fusepy
+```
+
 An example config ("config.yaml"):
 
 ```


### PR DESCRIPTION
Use sudo python -m pip install fusepy on Python 2.7 for the package to be installed in the correct path. If using pip only, then the package will be installed in the directory for Python 2.6.
